### PR TITLE
Fix card order in deck list

### DIFF
--- a/src/CardPicker/CardPicker.jsx
+++ b/src/CardPicker/CardPicker.jsx
@@ -3,7 +3,7 @@ import React, { useState, useEffect } from 'react'
 import { CollectionFilters } from './CollectionFilters'
 import { cards } from '../collection'
 import { CollectionList } from './CollectionList'
-import { decklistCardSort } from '../DeckList/DeckList'
+import { decklistCardComparator } from '../DeckList/DeckList'
 
 export function CardPicker ({ addCard }) {
   const [attributeFilter, setAttributeFilter] = useState([])
@@ -12,7 +12,7 @@ export function CardPicker ({ addCard }) {
   const [activeSearchFilter, setActiveSearchFilter] = useState('')
 
   useEffect(() => {
-    let filteredList = cards.sort(decklistCardSort)
+    let filteredList = cards.sort(decklistCardComparator)
 
     if (attributeFilter.length) {
       filteredList = cards.filter(({ Attributes }) =>

--- a/src/CardPicker/CardPicker.jsx
+++ b/src/CardPicker/CardPicker.jsx
@@ -3,7 +3,7 @@ import React, { useState, useEffect } from 'react'
 import { CollectionFilters } from './CollectionFilters'
 import { cards } from '../collection'
 import { CollectionList } from './CollectionList'
-import { decklistCardComparator } from '../DeckList/DeckList'
+import { cardCostComparator } from '../DeckList/DeckList'
 
 export function CardPicker ({ addCard }) {
   const [attributeFilter, setAttributeFilter] = useState([])
@@ -12,7 +12,7 @@ export function CardPicker ({ addCard }) {
   const [activeSearchFilter, setActiveSearchFilter] = useState('')
 
   useEffect(() => {
-    let filteredList = cards.sort(decklistCardComparator)
+    let filteredList = cards.sort(pickerCardComparator)
 
     if (attributeFilter.length) {
       filteredList = cards.filter(({ Attributes }) =>
@@ -53,4 +53,36 @@ export function CardPicker ({ addCard }) {
       )}
     </>
   )
+}
+
+const AttributeOrdering = {
+  strength: 1,
+  willpower: 2,
+  intelligence: 3,
+  agility: 4,
+  endurance: 5,
+  neutral: 6
+}
+
+function pickerCardComparator (a, b) {
+  if (a.Attributes[0] === 'neutral' || b.Attributes[0] === 'neutral') {
+    if (a.Attributes[0] === 'neutral' && b.Attributes[0] === 'neutral') {
+      return cardCostComparator(a, b)
+    }
+    return a.Attributes[0] === 'neutral' ? 1 : -1
+  }
+
+  if (a.Attributes.length > 1 && b.Attributes.length > 1) {
+    return cardCostComparator(a, b)
+  }
+
+  if (a.Attributes.length > 1 || b.Attributes.length > 1) {
+    return a.Attributes.length > 1 ? 1 : -1
+  }
+
+  if (a.Attributes[0] === b.Attributes[0]) {
+    return cardCostComparator(a, b)
+  }
+
+  return AttributeOrdering[a.Attributes[0]] - AttributeOrdering[b.Attributes[0]]
 }

--- a/src/DeckList/DeckList.jsx
+++ b/src/DeckList/DeckList.jsx
@@ -73,12 +73,16 @@ export const DeckList = ({ cardList, handleClickOpen }) => {
   )
 }
 
-export function decklistCardComparator(a, b) {
-  const costComparison = parseInt(a["Magicka Cost"]) - parseInt(b["Magicka Cost"])
+function decklistCardComparator(a, b) {
+  const costComparison = cardCostComparator(a, b)
 
   if (costComparison !== 0) {
     return costComparison
   }
 
   return a.Name.localeCompare(b.Name)
+}
+
+export function cardCostComparator(a, b) {
+  return parseInt(a["Magicka Cost"]) - parseInt(b["Magicka Cost"])
 }

--- a/src/DeckList/DeckList.jsx
+++ b/src/DeckList/DeckList.jsx
@@ -36,7 +36,7 @@ export const DeckList = ({ cardList, handleClickOpen }) => {
   const width = useWidth()
   const maxNumColumns = getNumberOfColumns(width)
   const cardsByCount = Object.entries(
-    cardList.sort(decklistCardSort).reduce((acc, next) => {
+    cardList.sort(decklistCardComparator).reduce((acc, next) => {
       if (acc[next.Name]) {
         return {
           ...acc,
@@ -73,38 +73,12 @@ export const DeckList = ({ cardList, handleClickOpen }) => {
   )
 }
 
-const AttributeOrdering = {
-  strength: 1,
-  willpower: 2,
-  intelligence: 3,
-  agility: 4,
-  endurance: 5,
-  neutral: 6
-}
+export function decklistCardComparator(a, b) {
+  const costComparison = parseInt(a["Magicka Cost"]) - parseInt(b["Magicka Cost"])
 
-export function decklistCardSort (a, b) {
-  if (a.Attributes[0] === 'neutral' || b.Attributes[0] === 'neutral') {
-    if (a.Attributes[0] === 'neutral' && b.Attributes[0] === 'neutral') {
-      return sortByCost(a, b)
-    }
-    return a.Attributes[0] === 'neutral' ? 1 : -1
+  if (costComparison !== 0) {
+    return costComparison
   }
 
-  if (a.Attributes.length > 1 && b.Attributes.length > 1) {
-    return sortByCost(a, b)
-  }
-
-  if (a.Attributes.length > 1 || b.Attributes.length > 1) {
-    return a.Attributes.length > 1 ? 1 : -1
-  }
-
-  if (a.Attributes[0] === b.Attributes[0]) {
-    return sortByCost(a, b)
-  }
-
-  return AttributeOrdering[a.Attributes[0]] - AttributeOrdering[b.Attributes[0]]
-}
-
-function sortByCost (a, b) {
-  return parseInt(a['Magicka Cost'], 10) - parseInt(b['Magicka Cost'], 10)
+  return a.Name.localeCompare(b.Name)
 }

--- a/src/DeckList/DeckList.jsx
+++ b/src/DeckList/DeckList.jsx
@@ -84,5 +84,5 @@ function decklistCardComparator(a, b) {
 }
 
 export function cardCostComparator(a, b) {
-  return parseInt(a["Magicka Cost"]) - parseInt(b["Magicka Cost"])
+  return parseInt(a['Magicka Cost']) - parseInt(b['Magicka Cost'])
 }


### PR DESCRIPTION
This PR fixes card order in the deck list by making it follow the same criteria used by the game's deck builder: cost first, name second. 

This PR also separates card ordering between deck list and card picker, because they need to follow different criteria. The original criteria for the card picker has been preserved by moving it in the picker's JSX file.